### PR TITLE
chore: allow to import devDeps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,9 @@
       "valid-typeof": [
           "error",
           { "requireStringLiterals": false }
-      ]
+      ],
+      "import/no-extraneous-dependencies": ["warn", {
+        "devDependencies": true
+      }]
   }
 }


### PR DESCRIPTION
set import/no-extraneous-dependencies.devDependencies back do default value